### PR TITLE
Added perUser filter and transform

### DIFF
--- a/src/configuration/defaults.js
+++ b/src/configuration/defaults.js
@@ -24,6 +24,7 @@ module.exports = function () {
         swagger: false,
         maxTop: 1000,
         pageSize: 50,
+        userIdColumn: 'userId',
         logging: {
             level: environment.debug ? 'debug' : 'info',
             transports: [

--- a/src/data/filters/index.js
+++ b/src/data/filters/index.js
@@ -1,0 +1,11 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+module.exports = {
+    apply: function (filter, query, context) {
+        return require('./' + filter).filter(query, context) || query;
+    },
+    applyTransform: function (transform, item, context) {
+        return require('./' + transform).transform(item, context) || item;
+    }
+}

--- a/src/data/filters/perUser.js
+++ b/src/data/filters/perUser.js
@@ -1,0 +1,18 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+
+module.exports = {
+    filter: function (query, context) {
+        return query.where(perUserPredicate(context));
+    },
+    transform: function (item, context) {
+        item[context.table.userIdColumn] = context.user && context.user.id;
+    }
+};
+
+function perUserPredicate(context) {
+    var predicate = {};
+    predicate[context.table.userIdColumn] = context.user && context.user.id;
+    return predicate;
+}

--- a/src/data/wrapProvider.js
+++ b/src/data/wrapProvider.js
@@ -1,7 +1,8 @@
 // ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
-var assert = require('../utilities/assert').argument,
+var filters = require('./filters'),
+    assert = require('../utilities/assert').argument,
     queries = require('../query');
 
 module.exports = function (provider, table, context) {
@@ -35,23 +36,28 @@ module.exports = function (provider, table, context) {
     };
 
     function applyFilters(query) {
+        if(table.perUser)
+            query = filters.apply('perUser', query, context);
+
         if(!table.filters)
             return query;
 
         return table.filters.reduce(function (query, filter) {
             // this is a bit of trickery to allow filters to either 
             // modify the existing query or return a different query
+            // see the test in data/integration/filters for an example                
             return filter(query, context) || query;
         }, query || queries.create(table.name));
     }
 
     function applyTransforms(item) {
+        if(table.perUser)
+            item = filters.applyTransform('perUser', item, context);
+
         if(!table.transforms)
             return item;
 
         return table.transforms.reduce(function (item, transform) {
-            // same trick as in filters
-            // see the test in data/integration/filters for an example                
             return transform(item, context) || item;
         }, item);
     }

--- a/src/express/tables/index.js
+++ b/src/express/tables/index.js
@@ -70,6 +70,7 @@ module.exports = function (configuration, data) {
         definition.name = definition.name || name;
         definition.containerName = definition.containerName || definition.databaseTableName || definition.name || name;
         definition.supportsSoftDelete = definition.softDelete;
+        definition.userIdColumn = definition.userIdColumn || configuration.userIdColumn;
 
         if (configuration.data && !definition.hasOwnProperty('dynamicSchema'))
             definition.dynamicSchema = configuration.data.dynamicSchema;
@@ -80,6 +81,12 @@ module.exports = function (configuration, data) {
         if (!definition.hasOwnProperty('pageSize'))
             definition.pageSize = configuration.pageSize;
 
+        if(definition.perUser) {
+            // this ensures the required user id column is created when initialize is called
+            definition.columns = definition.columns || {};
+            definition.columns[definition.userIdColumn] = 'string';
+        }
+        
         return definition;
     }
 }

--- a/test/express/integration/filters/perUser.tests.js
+++ b/test/express/integration/filters/perUser.tests.js
@@ -1,0 +1,118 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// ----------------------------------------------------------------------------
+var expect = require('chai').use(require('chai-subset')).expect,
+    supertest = require('supertest-as-promised'),
+    express = require('express'),
+    mobileApps = require('../../../appFactory'),
+    auth = require('../../../../src/auth'),
+
+    app, mobileApp;
+
+describe('azure-mobile-apps.express.integration.filters.perUser', function () {
+    beforeEach(function () { setup(); });
+    afterEach(mobileApps.cleanUp(mobileApps.configuration()).testTable({ name: 'perUser' }));
+
+    it("attaches user id property to item", function () {
+        return request('post', null, 'user1', 201, { id: '1', value: 'test' })()
+            .then(request('get', '1', 'user1', 200))
+            .then(validateProperty('userId', 'user1'));
+    });
+
+    it("allows all operations on records created by a user", function () {
+        return request('post', null, 'user1', 201, { id: '1', value: 'test' })()
+            .then(request('get', '1', 'user1', 200))
+            .then(request('patch', '1', 'user1', 200, { value: 'test2' }))
+            .then(request('delete', '1', 'user1', 200))
+            .then(request('post', '1', 'user1', 201));
+    });
+
+    it("disallows all operations on records not created by a user", function () {
+        return request('post', null, 'user1', 201, { id: '1', value: 'test' })()
+            .then(request('get', '1', 'user2', 404))
+            .then(request('get', '1', null, 404))
+            .then(request('patch', '1', 'user2', 404, { value: 'test2' }))
+            .then(request('delete', '1', 'user2', 404))
+            .then(request('post', '1', 'user2', 404));
+    });
+
+    it("restricts queries to specific users", function () {
+        return request('post', null, 'user1', 201, { id: '1', value: 'test1' })()
+            .then(request('post', null, 'user1', 201, { id: '2', value: 'test2' }))
+            .then(request('post', null, 'user2', 201, { id: '3', value: 'test1' }))
+            .then(request('post', null, 'user2', 201, { id: '4', value: 'test2' }))
+            .then(request('get', null, null, 200))
+            .then(validateIds([]))
+            .then(request('get', null, 'user1', 200))
+            .then(validateIds(['1', '2']))
+            .then(request('get', "?$filter=value eq 'test1'", 'user1', 200))
+            .then(validateIds(['1']))
+            .then(request('get', "?$filter=value eq 'test2'", 'user2', 200))
+            .then(validateIds(['4']));
+    });
+
+    it("uses user id column name specified on table", function () {
+        setup({ perUser: true, userIdColumn: 'table_user_id' });
+        return request('post', null, 'user1', 201, { id: '1', value: 'test' })()
+            .then(request('get', '1', 'user1', 200))
+            .then(validateProperty('table_user_id', 'user1'));
+    });
+
+    it("uses default user id column name specified in configuration", function () {
+        setup({ perUser: true }, { userIdColumn: 'config_user_id' });
+        return request('post', null, 'user1', 201, { id: '1', value: 'test' })()
+            .then(request('get', '1', 'user1', 200))
+            .then(validateProperty('config_user_id', 'user1'));
+    });
+
+    it("creates required columns when initialized", function () {
+        var table = mobileApp.table();
+        table.read(function(context) {
+            return context.data({ name: 'perUser' }).schema().then(function (schema) {
+                expect(schema.properties.filter(function (x) { return x.name === 'userId'; })[0].type).to.equal('string');
+                return [];
+            });
+        });
+        table.perUser = true;
+        setup(table);
+        return mobileApp.tables.initialize().then(request('get', null, 'user1', 200));
+    });
+
+    function setup(table, configuration) {
+        app = express();
+        mobileApp = mobileApps(configuration);
+        mobileApp.tables.add('perUser', table || { perUser: true, softDelete: true });
+        app.use(mobileApp);
+    }
+
+    function request(method, id, userId, expectedResponse, body) {
+        return function () {
+            var url = '/tables/perUser' + (id ? '/' + id : ''),
+                req = supertest(app)[method](url);
+
+            if(userId) req.set('x-zumo-auth', token(userId));
+            if(body) req.send(body);
+
+            return req.expect(expectedResponse);
+        };
+    }
+
+    function token(userId) {
+        return auth(mobileApp.configuration.auth).sign({ sub: userId });
+    }
+
+    function validateIds(ids) {
+        return function (results) {
+            expect(results.body.length).to.equal(ids.length);
+            ids.forEach(function (id, index) {
+                expect(results.body[index].id).to.equal(id);
+            });
+        }
+    }
+
+    function validateProperty(property, value) {
+        return function (results) {
+            expect(results.body[property]).to.equal(value);
+        };
+    }
+});


### PR DESCRIPTION
data/filters/perUser.js is the example of how to implement a filter and transform. A bit of extra infrastructure is required to hook up the declarative `perUser` property on table definitions, but not much.

@paulbatum @fabiocav @mamaso

This PR is contained in my repo as both branches used for comparison are in this repo. I will merge this PR into the first and then merge that one into the main repo master branch.